### PR TITLE
Fix: discussion-timeline Width Adjustment to Prevent Content Wrapping

### DIFF
--- a/github-custom-width.css
+++ b/github-custom-width.css
@@ -28,7 +28,7 @@
         width: calc(100% - 210px);
     }
     .discussion-timeline {
-        width: calc(100% - 160px);
+        width: calc(100% - 220px);
     }
     .org-main {
         width: calc(100% - 280px);


### PR DESCRIPTION
This PR fixes Issue #5 
